### PR TITLE
Share immutable block with `[@share]` attribute

### DIFF
--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -391,7 +391,7 @@ let comp_primitive p args =
   | Pcompare_ints -> Kccall("caml_int_compare", 2)
   | Pcompare_floats -> Kccall("caml_float_compare", 2)
   | Pcompare_bints bi -> comp_bint_primitive bi "compare" args
-  | Pfield n -> Kgetfield n
+  | Pfield (n, _) -> Kgetfield n
   | Pfield_computed -> Kgetvectitem
   | Psetfield(n, _ptr, _init) -> Ksetfield n
   | Psetfield_computed(_ptr, _init) -> Ksetvectitem

--- a/bytecomp/bytegen.ml
+++ b/bytecomp/bytegen.ml
@@ -785,7 +785,7 @@ let rec comp_expr env exp sz cont =
         | CFnge -> Kccall("caml_ge_float", 2) :: Kboolnot :: cont
       in
       comp_args env args sz cont
-  | Lprim(Pmakeblock(tag, _mut, _), args, loc) ->
+  | Lprim(Pmakeblock(tag, _mut, _, _), args, loc) ->
       let cont = add_pseudo_event loc !compunit_name cont in
       comp_args env args sz (Kmakeblock(List.length args, tag) :: cont)
   | Lprim(Pfloatfield n, args, loc) ->

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -48,7 +48,7 @@ type primitive =
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape
-  | Pfield of int
+  | Pfield of int * mutable_flag
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment
@@ -658,7 +658,7 @@ let rec transl_address loc = function
       then Lprim(Pgetglobal id, [], loc)
       else Lvar id
   | Env.Adot(addr, pos) ->
-      Lprim(Pfield pos, [transl_address loc addr], loc)
+      Lprim(Pfield (pos, Mutable), [transl_address loc addr], loc)
 
 let transl_path find loc env path =
   match find path env with

--- a/lambda/lambda.ml
+++ b/lambda/lambda.ml
@@ -39,6 +39,11 @@ type is_safe =
   | Safe
   | Unsafe
 
+type share_immutable_attribute =
+  | Always_share_immutable (* [@share] or [@share always] *)
+  | Hint_share_immutable (* [@share hint] *)
+  | Default_share_immutable (* [@share never] or no [@share] attribute *)
+
 type primitive =
   | Pbytes_to_string
   | Pbytes_of_string
@@ -47,7 +52,7 @@ type primitive =
   | Pgetglobal of Ident.t
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
-  | Pmakeblock of int * mutable_flag * block_shape
+  | Pmakeblock of int * mutable_flag * share_immutable_attribute * block_shape
   | Pfield of int * mutable_flag
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -54,7 +54,7 @@ type primitive =
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
   | Pmakeblock of int * mutable_flag * block_shape
-  | Pfield of int
+  | Pfield of int * mutable_flag
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment
   | Psetfield_computed of immediate_or_pointer * initialization_or_assignment

--- a/lambda/lambda.mli
+++ b/lambda/lambda.mli
@@ -45,6 +45,11 @@ type is_safe =
   | Safe
   | Unsafe
 
+type share_immutable_attribute =
+  | Always_share_immutable (* [@share] or [@share always] *)
+  | Hint_share_immutable (* [@share hint] *)
+  | Default_share_immutable (* [@share never] or no [@share] attribute *)
+
 type primitive =
   | Pbytes_to_string
   | Pbytes_of_string
@@ -53,7 +58,7 @@ type primitive =
   | Pgetglobal of Ident.t
   | Psetglobal of Ident.t
   (* Operations on heap blocks *)
-  | Pmakeblock of int * mutable_flag * block_shape
+  | Pmakeblock of int * mutable_flag * share_immutable_attribute * block_shape
   | Pfield of int * mutable_flag
   | Pfield_computed
   | Psetfield of int * immediate_or_pointer * initialization_or_assignment

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -1766,7 +1766,7 @@ let get_expr_args_constr ~scopes head (arg, _mut) rem =
       if pos > last_pos then
         argl
       else
-        (Lprim (Pfield pos, [ arg ], loc), binding_kind) :: make_args (pos + 1)
+        (Lprim (Pfield (pos, Immutable), [ arg ], loc), binding_kind) :: make_args (pos + 1)
     in
     make_args first_pos
   in
@@ -1794,7 +1794,7 @@ let get_expr_args_variant_constant = drop_expr_arg
 
 let get_expr_args_variant_nonconst ~scopes head (arg, _mut) rem =
   let loc = head_loc ~scopes head in
-  (Lprim (Pfield 1, [ arg ], loc), Alias) :: rem
+  (Lprim (Pfield (1, Immutable), [ arg ], loc), Alias) :: rem
 
 let divide_variant ~scopes row ctx { cases = cl; args; default = def } =
   let rec divide = function
@@ -1910,7 +1910,7 @@ let inline_lazy_force_cond arg loc =
                 ( Pintcomp Ceq,
                   [ tag_var; Lconst (Const_base (Const_int Obj.forward_tag)) ],
                   loc ),
-              Lprim (Pfield 0, [ varg ], loc),
+              Lprim (Pfield (0, Mutable), [ varg ], loc),
               Lifthenelse
                 (* if (tag == Obj.lazy_tag) then Lazy.force varg else ... *)
                 ( Lprim
@@ -1947,7 +1947,7 @@ let inline_lazy_force_switch arg loc =
                 sw_numblocks = 256;
                 (* PR#6033 - tag ranges from 0 to 255 *)
                 sw_blocks =
-                  [ (Obj.forward_tag, Lprim (Pfield 0, [ varg ], loc));
+                  [ (Obj.forward_tag, Lprim (Pfield (0, Mutable), [ varg ], loc));
                     ( Obj.lazy_tag,
                       Lapply
                         { ap_tailcall = Default_tailcall;
@@ -2009,7 +2009,7 @@ let get_expr_args_tuple ~scopes head (arg, _mut) rem =
     if pos >= arity then
       rem
     else
-      (Lprim (Pfield pos, [ arg ], loc), Alias) :: make_args (pos + 1)
+      (Lprim (Pfield (pos, Immutable), [ arg ], loc), Alias) :: make_args (pos + 1)
   in
   make_args 0
 
@@ -2053,10 +2053,10 @@ let get_expr_args_record ~scopes head (arg, _mut) rem =
         match lbl.lbl_repres with
         | Record_regular
         | Record_inlined _ ->
-            Lprim (Pfield lbl.lbl_pos, [ arg ], loc)
+            Lprim (Pfield (lbl.lbl_pos, lbl.lbl_mut), [ arg ], loc)
         | Record_unboxed _ -> arg
         | Record_float -> Lprim (Pfloatfield lbl.lbl_pos, [ arg ], loc)
-        | Record_extension _ -> Lprim (Pfield (lbl.lbl_pos + 1), [ arg ], loc)
+        | Record_extension _ -> Lprim (Pfield (lbl.lbl_pos + 1, lbl.lbl_mut), [ arg ], loc)
       in
       let str =
         match lbl.lbl_mut with
@@ -2802,7 +2802,7 @@ let combine_constructor loc arg pat_env cstr partial ctx def
                       (Lprim (Pintcomp Ceq, [ Lvar tag; ext ], loc), act, rem))
                   nonconsts default
               in
-              Llet (Alias, Pgenval, tag, Lprim (Pfield 0, [ arg ], loc), tests)
+              Llet (Alias, Pgenval, tag, Lprim (Pfield (0, Immutable), [ arg ], loc), tests)
         in
         List.fold_right
           (fun (path, act) rem ->
@@ -2897,7 +2897,7 @@ let call_switcher_variant_constr loc fail arg int_lambda_list =
     ( Alias,
       Pgenval,
       v,
-      Lprim (Pfield 0, [ arg ], loc),
+      Lprim (Pfield (0, Immutable), [ arg ], loc),
       call_switcher loc fail (Lvar v) min_int max_int int_lambda_list )
 
 let combine_variant loc row arg partial ctx def (tag_lambda_list, total1, _pats)

--- a/lambda/matching.ml
+++ b/lambda/matching.ml
@@ -3442,7 +3442,7 @@ let failure_handler ~scopes loc ~failer () =
     Lprim
       ( Praise Raise_regular,
         [ Lprim
-            ( Pmakeblock (0, Immutable, None),
+            ( Pmakeblock (0, Immutable, Default_share_immutable, None),
               [ slot;
                 Lconst
                   (Const_block
@@ -3761,7 +3761,7 @@ let do_for_multiple_match ~scopes loc paraml pat_act_list partial =
   let repr = None in
   let arg =
     let sloc = Scoped_location.of_location ~scopes loc in
-    Lprim (Pmakeblock (0, Immutable, None), paraml, sloc) in
+    Lprim (Pmakeblock (0, Immutable, Default_share_immutable, None), paraml, sloc) in
   let handler =
     let partial = check_partial pat_act_list partial in
     let rows = map_on_rows (fun p -> (p, [])) pat_act_list in

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -156,7 +156,8 @@ let primitive ppf = function
       fprintf ppf "makeblock %i%a" tag block_shape shape
   | Pmakeblock(tag, Mutable, shape) ->
       fprintf ppf "makemutable %i%a" tag block_shape shape
-  | Pfield n -> fprintf ppf "field %i" n
+  | Pfield (n, Immutable) -> fprintf ppf "field %i" n
+  | Pfield (n, Mutable) -> fprintf ppf "field_mut %i" n
   | Pfield_computed -> fprintf ppf "field_computed"
   | Psetfield(n, ptr, init) ->
       let instr =

--- a/lambda/printlambda.ml
+++ b/lambda/printlambda.ml
@@ -146,16 +146,21 @@ let float_comparison ppf = function
   | CFge -> fprintf ppf ">=."
   | CFnge -> fprintf ppf "!>=."
 
+let share_immutable_attribute ppf = function
+  | Default_share_immutable -> ()
+  | Always_share_immutable -> fprintf ppf " share(always)"
+  | Hint_share_immutable -> fprintf ppf " share(hint)"
+
 let primitive ppf = function
   | Pbytes_to_string -> fprintf ppf "bytes_to_string"
   | Pbytes_of_string -> fprintf ppf "bytes_of_string"
   | Pignore -> fprintf ppf "ignore"
   | Pgetglobal id -> fprintf ppf "global %a" Ident.print id
   | Psetglobal id -> fprintf ppf "setglobal %a" Ident.print id
-  | Pmakeblock(tag, Immutable, shape) ->
-      fprintf ppf "makeblock %i%a" tag block_shape shape
-  | Pmakeblock(tag, Mutable, shape) ->
-      fprintf ppf "makemutable %i%a" tag block_shape shape
+  | Pmakeblock(tag, Immutable, si, shape) ->
+      fprintf ppf "makeblock %i%a%a" tag block_shape shape share_immutable_attribute si
+  | Pmakeblock(tag, Mutable, si, shape) ->
+      fprintf ppf "makemutable %i%a%a" tag block_shape shape share_immutable_attribute si
   | Pfield (n, Immutable) -> fprintf ppf "field %i" n
   | Pfield (n, Mutable) -> fprintf ppf "field_mut %i" n
   | Pfield_computed -> fprintf ppf "field_computed"

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -888,6 +888,122 @@ let simplify_local_functions lam =
   else
     rewrite lam
 
+
+(* Reuse immutable blocks with the same tag as the variable
+   in the context. *)
+
+module Int = Numbers.Int
+
+type reuse_ctx = {
+  known_tag_of_var: int Ident.Map.t;
+  known_var_with_tag: Ident.t list Int.Map.t;
+}
+
+let empty_reuse_ctx =
+  { known_tag_of_var = Ident.Map.empty;
+    known_var_with_tag = Int.Map.empty; }
+
+let reuse_ctx_add ctx var tag =
+  { known_tag_of_var = 
+      Ident.Map.add var tag ctx.known_tag_of_var
+  ; known_var_with_tag = 
+      Int.Map.add tag 
+        (var :: Option.value ~default:[] (Int.Map.find_opt tag ctx.known_var_with_tag))
+        ctx.known_var_with_tag }
+
+let reuse_immutable_block lam =
+  let rec reuse lam ~ctx =
+    match lam with
+    | Lvar _ | Lmutvar _ | Lconst _ -> lam
+    | Lapply ap ->
+        Lapply{ap with ap_func = reuse ap.ap_func ~ctx;
+                        ap_args = List.map (reuse ~ctx) ap.ap_args }
+    | Lfunction{kind; params; return; body = l; attr; loc} ->
+      lfunction ~kind ~params ~return ~body:(reuse l ~ctx) ~attr ~loc
+    | Llet (str, kind, v, l1, l2) ->
+      Llet (str, kind, v, reuse l1 ~ctx, reuse l2 ~ctx)
+    | Lmutlet (kind, v, l1, l2) ->
+      Lmutlet (kind, v, reuse l1 ~ctx, reuse l2 ~ctx)
+    | Lletrec (bindings, body) ->
+      Lletrec (List.map (fun (id, l) -> (id, reuse l ~ctx)) bindings,
+        reuse body ~ctx)
+    (*
+      reuse block of the form of
+        (makeblock id ... (field 0 v, field 1 v, ..., field n v)) 
+          where n >= 0
+                v is a variable with a known tag to be the same as id
+      if args is [], then we just choose the last variable with the same id in the ctx
+    *)
+    | Lprim (Pmakeblock (id, Immutable, _shape), [], _loc) ->
+      begin match Int.Map.find_opt id ctx.known_var_with_tag with
+        | Some (hd :: _) -> Lvar hd
+        | _ -> lam
+      end
+    | Lprim (Pmakeblock (id, Immutable, _shape), 
+             (Lprim ((Pfield (0, Immutable)), [Lvar v], _loc)) :: xs, _loc2) ->
+      begin match Ident.Map.find_opt v ctx.known_tag_of_var with
+        | Some tag when tag = id ->
+          let arg_cond (flag, i) arg =
+            match arg with
+            | Lprim ((Pfield (i', Immutable)), [Lvar v'], _loc) when v = v' && i = i' -> 
+              (flag, i + 1)
+            | _ -> (false, i + 1)
+          in
+          let (args_satified, _) = List.fold_left arg_cond (true, 1) xs in
+          if args_satified then Lvar v else lam
+        | _ -> lam
+      end
+    | Lprim (prim, args, loc) ->
+      Lprim (prim, List.map (reuse ~ctx) args, loc)
+    | Lswitch (Lvar v, sw, loc) ->
+      (* TODO: handle the case scrutinee is not a var *)
+      let update_ctx tag = reuse_ctx_add ctx v tag in
+      let new_consts = List.map (fun (n, e) -> (n, reuse e ~ctx)) sw.sw_consts
+      and new_blocks = List.map (fun (n, e) -> (n, reuse e ~ctx:(update_ctx n))) sw.sw_blocks
+      and new_fail = Option.map (reuse ~ctx) sw.sw_failaction in
+      Lswitch
+        (Lvar v,
+          {sw with sw_consts = new_consts ; sw_blocks = new_blocks;
+                   sw_failaction = new_fail},
+          loc)
+    | Lswitch(l, sw, loc) ->
+      let new_l = reuse l ~ctx
+      and new_consts = List.map (fun (n, e) -> (n, reuse e ~ctx)) sw.sw_consts
+      and new_blocks = List.map (fun (n, e) -> (n, reuse e ~ctx)) sw.sw_blocks
+      and new_fail = Option.map (reuse ~ctx) sw.sw_failaction in
+      Lswitch
+        (new_l,
+          {sw with sw_consts = new_consts ; sw_blocks = new_blocks;
+                   sw_failaction = new_fail},
+          loc)
+    | Lstringswitch (l, sw, d, loc) ->
+      Lstringswitch (reuse l ~ctx,List.map (fun (s,l) -> s, reuse l ~ctx) sw,
+       Option.map (reuse ~ctx) d,loc)
+    | Lstaticraise (i, args) -> 
+      Lstaticraise (i, List.map (reuse ~ctx) args)
+    | Lstaticcatch (l1, (i, vars), l2) -> 
+      Lstaticcatch (reuse l1 ~ctx, (i, vars), reuse l2 ~ctx)
+    | Ltrywith (l1, id, l2) -> 
+      Ltrywith (reuse l1 ~ctx, id, reuse l2 ~ctx)
+    | Lifthenelse (c, t, f) -> 
+      Lifthenelse (reuse c ~ctx, reuse t ~ctx, reuse f ~ctx)
+    | Lsequence (l1, l2) -> 
+      Lsequence (reuse l1 ~ctx, reuse l2 ~ctx)
+    | Lwhile (c, body) -> 
+      Lwhile (reuse c ~ctx, reuse body ~ctx)
+    | Lfor (v, low, high, dir, body) -> 
+      Lfor (v, reuse low ~ctx, reuse high ~ctx, dir, reuse body ~ctx)
+    | Lassign (v, l) -> 
+      Lassign (v, reuse l ~ctx)
+    | Lsend (k, m, o, ll, loc) ->
+      Lsend (k, reuse m ~ctx, reuse o ~ctx,
+        List.map (reuse ~ctx) ll, loc)
+    | Levent (l, ev) -> 
+      Levent (reuse l ~ctx, ev)
+    | Lifused (v, l) -> 
+      Lifused (v, reuse l ~ctx)
+  in reuse lam ~ctx:empty_reuse_ctx
+
 (* The entry point:
    simplification
    + rewriting of tail-modulo-cons calls
@@ -902,6 +1018,7 @@ let simplify_lambda lam =
        )
     |> simplify_exits
     |> simplify_lets
+    |> reuse_immutable_block
     |> Tmc.rewrite
   in
   if !Clflags.annotations

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -42,7 +42,7 @@ let rec eliminate_ref id = function
   | Lletrec(idel, e2) ->
       Lletrec(List.map (fun (v, e) -> (v, eliminate_ref id e)) idel,
               eliminate_ref id e2)
-  | Lprim(Pfield 0, [Lvar v], _) when Ident.same v id ->
+  | Lprim(Pfield (0, _), [Lvar v], _) when Ident.same v id ->
       Lmutvar id
   | Lprim(Psetfield(0, _, _), [Lvar v; e], _) when Ident.same v id ->
       Lassign(id, eliminate_ref id e)

--- a/lambda/simplif.ml
+++ b/lambda/simplif.ml
@@ -234,8 +234,8 @@ let simplify_exits lam =
         (* Simplify Obj.with_tag *)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
         [Lconst (Const_base (Const_int tag));
-         Lprim (Pmakeblock (_, mut, shape), fields, loc)] ->
-         Lprim (Pmakeblock(tag, mut, shape), fields, loc)
+         Lprim (Pmakeblock (_, mut, share_immut, shape), fields, loc)] ->
+         Lprim (Pmakeblock(tag, mut, share_immut, shape), fields, loc)
       | Pccall { Primitive.prim_name = "caml_obj_with_tag"; _ },
         [Lconst (Const_base (Const_int tag));
          Lconst (Const_block (_, fields))] ->
@@ -528,7 +528,7 @@ let simplify_lets lam =
       Hashtbl.add subst v (simplif (Lvar w));
       simplif l2
   | Llet(Strict, kind, v,
-         Lprim(Pmakeblock(0, Mutable, kind_ref) as prim, [linit], loc), lbody)
+         Lprim(Pmakeblock(0, Mutable, _, kind_ref) as prim, [linit], loc), lbody)
     when optimize ->
       let slinit = simplif linit in
       let slbody = simplif lbody in
@@ -912,6 +912,11 @@ let reuse_ctx_add ctx var tag =
         ctx.known_var_with_tag }
 
 let reuse_immutable_block lam =
+  let warn_always loc = function
+    | Hint_share_immutable | Default_share_immutable -> ()
+    | Always_share_immutable ->
+      Location.prerr_warning (to_location loc) (Warnings.Share_immutable_block_failed)
+  in
   let rec reuse lam ~ctx =
     match lam with
     | Lvar _ | Lmutvar _ | Lconst _ -> lam
@@ -934,13 +939,19 @@ let reuse_immutable_block lam =
                 v is a variable with a known tag to be the same as id
       if args is [], then we just choose the last variable with the same id in the ctx
     *)
-    | Lprim (Pmakeblock (id, Immutable, _shape), [], _loc) ->
+    | Lprim (Pmakeblock (id, Immutable, (Hint_share_immutable | Always_share_immutable as si), _shape), [], loc) ->
       begin match Int.Map.find_opt id ctx.known_var_with_tag with
         | Some (hd :: _) -> Lvar hd
-        | _ -> lam
+        | _ ->
+          warn_always loc si;
+          lam
       end
-    | Lprim (Pmakeblock (id, Immutable, _shape), 
-             (Lprim ((Pfield (0, Immutable)), [Lvar v], _loc)) :: xs, _loc2) ->
+    | Lprim (Pmakeblock (id, Immutable, (Hint_share_immutable | Always_share_immutable as si), _shape) as prim, 
+             ((Lprim ((Pfield (0, Immutable)), [Lvar v], _loc)) :: xs as args), loc) ->
+      let failed () =
+        warn_always loc si;
+        Lprim (prim, List.map (reuse ~ctx) args, loc)
+      in
       begin match Ident.Map.find_opt v ctx.known_tag_of_var with
         | Some tag when tag = id ->
           let arg_cond (flag, i) arg =
@@ -950,9 +961,13 @@ let reuse_immutable_block lam =
             | _ -> (false, i + 1)
           in
           let (args_satified, _) = List.fold_left arg_cond (true, 1) xs in
-          if args_satified then Lvar v else lam
-        | _ -> lam
+          if args_satified then Lvar v
+          else failed ()
+        | _ -> failed ()
       end
+    | Lprim (Pmakeblock (_, _, si, _shape) as prim, args, loc) ->
+      warn_always loc si;
+      Lprim (prim, List.map (reuse ~ctx) args, loc)
     | Lprim (prim, args, loc) ->
       Lprim (prim, List.map (reuse ~ctx) args, loc)
     | Lswitch (Lvar v, sw, loc) ->

--- a/lambda/tmc.ml
+++ b/lambda/tmc.ml
@@ -119,7 +119,7 @@ end = struct
 
   let apply constr t =
     let block_args = List.append constr.before @@ t :: constr.after in
-    Lprim (Pmakeblock (constr.tag, constr.flag, constr.shape),
+    Lprim (Pmakeblock (constr.tag, constr.flag, Default_share_immutable, constr.shape),
            block_args, constr.loc)
 
   let tmc_placeholder =
@@ -734,11 +734,11 @@ let rec choice ctx t =
         direct = (fun () -> Lapply apply_no_bailout);
       }
 
-  and choice_makeblock ctx ~tail:_ (tag, flag, shape) blockargs loc =
+  and choice_makeblock ctx ~tail:_ (tag, flag, share_immut, shape) blockargs loc =
     let choices = List.map (choice ctx ~tail:false) blockargs in
     match Choice.find_nonambiguous_tmc_call choices with
     | Choice.No_tmc_call args ->
-        Choice.lambda @@ Lprim (Pmakeblock (tag, flag, shape), args, loc)
+        Choice.lambda @@ Lprim (Pmakeblock (tag, flag, share_immut, shape), args, loc)
     | Choice.Ambiguous { explicit; subterms = ambiguous_subterms } ->
         (* An ambiguous term should not lead to an error if it not
            used in TMC position. Consider for example:
@@ -775,7 +775,7 @@ let rec choice ctx t =
         *)
         let term_choice =
           let+ args = Choice.list choices in
-          Lprim (Pmakeblock(tag, flag, shape), args, loc)
+          Lprim (Pmakeblock(tag, flag, share_immut, shape), args, loc)
         in
         { term_choice with
           Choice.dps = Dps.make (fun ~tail:_ ~dst:_ ->
@@ -826,8 +826,8 @@ let rec choice ctx t =
   and choice_prim ctx ~tail prim primargs loc =
     match prim with
     (* The important case is the construction case *)
-    | Pmakeblock (tag, flag, shape) ->
-        choice_makeblock ctx ~tail (tag, flag, shape) primargs loc
+    | Pmakeblock (tag, flag, share_immut, shape) ->
+        choice_makeblock ctx ~tail (tag, flag, share_immut, shape) primargs loc
 
     (* Some primitives have arguments in tail-position *)
     | Popaque ->

--- a/lambda/translattribute.ml
+++ b/lambda/translattribute.ml
@@ -192,6 +192,20 @@ let parse_poll_attribute attr =
         ]
         payload
 
+let parse_share_immutable_attribute attr =
+  match attr with
+  | None -> Default_share_immutable
+  | Some {Parsetree.attr_name = {txt; loc}; attr_payload = payload} ->
+      parse_id_payload txt loc
+        ~default:Default_share_immutable
+        ~empty:Always_share_immutable
+        [
+          "never", Default_share_immutable;
+          "always", Always_share_immutable;
+          "hint", Hint_share_immutable;
+        ]
+        payload
+
 let get_inline_attribute l =
   let attr, _ = find_attribute is_inline_attribute l in
   parse_inline_attribute attr
@@ -397,6 +411,16 @@ let get_tailcall_attribute e =
             Default_tailcall
       in
       tailcall_attribute, { e with exp_attributes = other_attributes }
+
+let get_share_immutable_attribute e =
+  let is_share_immutable_attribute = function
+    | {txt=("share")} -> true
+    | _ -> false
+  in
+  let attr, _ =
+    find_attribute is_share_immutable_attribute e.exp_attributes
+  in
+  parse_share_immutable_attribute attr
 
 let check_attribute e {Parsetree.attr_name = { txt; loc }; _} =
   match txt with

--- a/lambda/translattribute.mli
+++ b/lambda/translattribute.mli
@@ -69,6 +69,10 @@ val get_tailcall_attribute
    : Typedtree.expression
   -> Lambda.tailcall_attribute * Typedtree.expression
 
+val get_share_immutable_attribute 
+   : Typedtree.expression
+  -> Lambda.share_immutable_attribute
+
 val add_function_attributes
   : Lambda.lambda
   -> Location.t

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -63,7 +63,7 @@ let mkappl (func, args) =
 let lsequence l1 l2 =
   if l2 = lambda_unit then l1 else Lsequence(l1, l2)
 
-let lfield v i = Lprim(Pfield i, [Lvar v], Loc_unknown)
+let lfield v i = Lprim(Pfield (i, Mutable), [Lvar v], Loc_unknown)
 
 let transl_label l = share (Const_immstring l)
 
@@ -134,7 +134,7 @@ let rec build_object_init ~scopes cl_table obj params inh_init obj_init cl =
       let env =
         match envs with None -> []
         | Some envs ->
-            [Lprim(Pfield (List.length inh_init + 1),
+            [Lprim(Pfield (List.length inh_init + 1, Mutable),
                    [Lvar envs],
                    Loc_unknown)]
       in
@@ -280,8 +280,8 @@ let rec build_class_init ~scopes cla cstr super inh_init cl_init msubst top cl =
       | (_, path_lam, obj_init)::inh_init ->
           (inh_init,
            Llet (Strict, Pgenval, obj_init,
-                 mkappl(Lprim(Pfield 1, [path_lam], Loc_unknown), Lvar cla ::
-                        if top then [Lprim(Pfield 3, [path_lam], Loc_unknown)]
+                 mkappl(Lprim(Pfield (1, Mutable), [path_lam], Loc_unknown), Lvar cla ::
+                        if top then [Lprim(Pfield (3, Mutable), [path_lam], Loc_unknown)]
                         else []),
                  bind_super cla super cl_init))
       | _ ->
@@ -547,7 +547,7 @@ let rec builtin_meths self env env2 body =
     | p when const_path p -> "const", [p]
     | Lprim(Parrayrefu _, [Lvar s; Lvar n], _) when List.mem s self ->
         "var", [Lvar n]
-    | Lprim(Pfield n, [Lvar e], _) when Ident.same e env ->
+    | Lprim(Pfield (n, _), [Lvar e], _) when Ident.same e env ->
         "env", [Lvar env2; Lconst(const_int n)]
     | Lsend(Self, met, Lvar s, [], _) when List.mem s self ->
         "meth", [met]
@@ -846,7 +846,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
           Loc_unknown)
   and linh_envs =
     List.map
-      (fun (_, path_lam, _) -> Lprim(Pfield 3, [path_lam], Loc_unknown))
+      (fun (_, path_lam, _) -> Lprim(Pfield (3, Mutable), [path_lam], Loc_unknown))
       (List.rev inh_init)
   in
   let make_envs lam =
@@ -866,7 +866,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   in
   let inh_keys =
     List.map
-      (fun (_, path_lam, _) -> Lprim(Pfield 1, [path_lam], Loc_unknown))
+      (fun (_, path_lam, _) -> Lprim(Pfield (1, Mutable), [path_lam], Loc_unknown))
       inh_paths
   in
   let lclass lam =

--- a/lambda/translclass.ml
+++ b/lambda/translclass.ml
@@ -256,7 +256,7 @@ let output_methods tbl methods lam =
       lsequence (mkappl(oo_prim "set_method", [Lvar tbl; lab; code])) lam
   | _ ->
       lsequence (mkappl(oo_prim "set_methods",
-                        [Lvar tbl; Lprim(Pmakeblock(0,Immutable,None),
+                        [Lvar tbl; Lprim(Pmakeblock(0,Immutable,Default_share_immutable,None),
                                          methods, Loc_unknown)]))
         lam
 
@@ -516,7 +516,7 @@ let transl_class_rebind ~scopes cl vf =
     Strict, Pgenval, new_init, lfunction [obj_init, Pgenval] obj_init',
     Llet(
     Alias, Pgenval, cla, path_lam,
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
           [mkappl(Lvar new_init, [lfield cla 0]);
            lfunction [table, Pgenval]
              (Llet(Strict, Pgenval, env_init,
@@ -808,12 +808,12 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
       Strict, Pgenval, env_init, mkappl (Lvar class_init, [Lvar table]),
       Lsequence(
       mkappl (oo_prim "init_class", [Lvar table]),
-      Lprim(Pmakeblock(0, Immutable, None),
+      Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
             [mkappl (Lvar env_init, [lambda_unit]);
              Lvar class_init; Lvar env_init; lambda_unit],
             Loc_unknown))))
   and lbody_virt lenvs =
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
           [lambda_unit; Lambda.lfunction
                           ~kind:Curried
                           ~attr:default_function_attribute
@@ -837,11 +837,11 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   let lenv =
     let menv =
       if !new_ids_meths = [] then lambda_unit else
-      Lprim(Pmakeblock(0, Immutable, None),
+      Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
             List.map (fun id -> Lvar id) !new_ids_meths,
             Loc_unknown) in
     if !new_ids_init = [] then menv else
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
           menv :: List.map (fun id -> Lvar id) !new_ids_init,
           Loc_unknown)
   and linh_envs =
@@ -852,7 +852,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   let make_envs lam =
     Llet(StrictOpt, Pgenval, envs,
          (if linh_envs = [] then lenv else
-         Lprim(Pmakeblock(0, Immutable, None),
+         Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
                lenv :: linh_envs, Loc_unknown)),
          lam)
   and def_ids cla lam =
@@ -881,7 +881,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
     if inh_keys = [] then Llet(Alias, Pgenval, cached, Lvar tables, lam) else
     Llet(Strict, Pgenval, cached,
          mkappl (oo_prim "lookup_tables",
-                [Lvar tables; Lprim(Pmakeblock(0, Immutable, None),
+                [Lvar tables; Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
                                     inh_keys, Loc_unknown)]),
          lam)
   and lset cached i lam =
@@ -922,7 +922,7 @@ let transl_class ~scopes ids cl_id pub_meths cl vflag =
   Lsequence(lcheck_cache,
   make_envs (
   if ids = [] then mkappl (lfield cached 0, [lenvs]) else
-  Lprim(Pmakeblock(0, Immutable, None),
+  Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
         (if concrete then
           [mkappl (lfield cached 0, [lenvs]);
            lfield cached 1;

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -373,14 +373,14 @@ and transl_exp0 ~in_new_scope ~scopes e =
       let targ = transl_exp ~scopes arg in
       begin match lbl.lbl_repres with
           Record_regular | Record_inlined _ ->
-          Lprim (Pfield lbl.lbl_pos, [targ],
+          Lprim (Pfield (lbl.lbl_pos, lbl.lbl_mut), [targ],
                  of_location ~scopes e.exp_loc)
         | Record_unboxed _ -> targ
         | Record_float ->
           Lprim (Pfloatfield lbl.lbl_pos, [targ],
                  of_location ~scopes e.exp_loc)
         | Record_extension _ ->
-          Lprim (Pfield (lbl.lbl_pos + 1), [targ],
+          Lprim (Pfield (lbl.lbl_pos + 1, lbl.lbl_mut), [targ],
                  of_location ~scopes e.exp_loc)
       end
   | Texp_setfield(arg, _, lbl, newval) ->
@@ -489,7 +489,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
       Lapply{
         ap_loc=loc;
         ap_func=
-          Lprim(Pfield 0, [transl_class_path loc e.exp_env cl], loc);
+          Lprim(Pfield (0, Mutable), [transl_class_path loc e.exp_env cl], loc);
         ap_args=[lambda_unit];
         ap_tailcall=Default_tailcall;
         ap_inlined=Default_inline;
@@ -622,7 +622,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
           let body, _ =
             List.fold_left (fun (body, pos) id ->
               Llet(Alias, Pgenval, id,
-                   Lprim(Pfield pos, [Lvar oid],
+                   Lprim(Pfield (pos, Mutable), [Lvar oid],
                          of_location ~scopes od.open_loc), body),
               pos + 1
             ) (transl_exp ~scopes e, 0)
@@ -944,15 +944,16 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
     let init_id = Ident.create_local "init" in
     let lv =
       Array.mapi
-        (fun i (_, definition) ->
+        (fun i (lbl, definition) ->
            match definition with
            | Kept typ ->
                let field_kind = value_kind env typ in
                let access =
+                 (* TODO: latest ocaml use mut flags in Kept *)
                  match repres with
-                   Record_regular | Record_inlined _ -> Pfield i
+                   Record_regular | Record_inlined _ -> Pfield (i, lbl.lbl_mut)
                  | Record_unboxed _ -> assert false
-                 | Record_extension _ -> Pfield (i + 1)
+                 | Record_extension _ -> Pfield ((i + 1), lbl.lbl_mut)
                  | Record_float -> Pfloatfield i in
                Lprim(access, [Lvar init_id],
                      of_location ~scopes loc),

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -62,7 +62,7 @@ let transl_extension_constructor ~scopes env path ext =
   let loc = of_location ~scopes ext.ext_loc in
   match ext.ext_kind with
     Text_decl _ ->
-      Lprim (Pmakeblock (Obj.object_tag, Immutable, None),
+      Lprim (Pmakeblock (Obj.object_tag, Immutable, Default_share_immutable, None),
         [Lconst (Const_base (Const_string (name, ext.ext_loc, None)));
          Lprim (prim_fresh_oo_id, [Lconst (const_int 0)], loc)],
         loc)
@@ -197,7 +197,7 @@ let assert_failed ~scopes exp =
   in
   let loc = of_location ~scopes exp.exp_loc in
   Lprim(Praise Raise_regular, [event_after ~scopes exp
-    (Lprim(Pmakeblock(0, Immutable, None),
+    (Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
           [slot;
            Lconst(Const_block(0,
               [Const_base(Const_string (fname, exp.exp_loc, None));
@@ -318,14 +318,20 @@ and transl_exp0 ~in_new_scope ~scopes e =
                Matching.for_trywith ~scopes e.exp_loc (Lvar id)
                  (transl_cases_try ~scopes pat_expr_list))
   | Texp_tuple el ->
+      let share_immutable =
+        Translattribute.get_share_immutable_attribute e
+      in
       let ll, shape = transl_list_with_shape ~scopes el in
       begin try
         Lconst(Const_block(0, List.map extract_constant ll))
       with Not_constant ->
-        Lprim(Pmakeblock(0, Immutable, Some shape), ll,
+        Lprim(Pmakeblock(0, Immutable, share_immutable, Some shape), ll,
               (of_location ~scopes e.exp_loc))
       end
   | Texp_construct(_, cstr, args) ->
+      let share_immutable =
+        Translattribute.get_share_immutable_attribute e
+      in
       let ll, shape = transl_list_with_shape ~scopes args in
       if cstr.cstr_inlined <> None then begin match ll with
         | [x] -> x
@@ -339,7 +345,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
           begin try
             Lconst(Const_block(n, List.map extract_constant ll))
           with Not_constant ->
-            Lprim(Pmakeblock(n, Immutable, Some shape), ll,
+            Lprim(Pmakeblock(n, Immutable, share_immutable, Some shape), ll,
                   of_location ~scopes e.exp_loc)
           end
       | Cstr_extension(path, is_const) ->
@@ -347,12 +353,15 @@ and transl_exp0 ~in_new_scope ~scopes e =
                       (of_location ~scopes e.exp_loc) e.exp_env path in
           if is_const then lam
           else
-            Lprim(Pmakeblock(0, Immutable, Some (Pgenval :: shape)),
+            Lprim(Pmakeblock(0, Immutable, share_immutable, Some (Pgenval :: shape)),
                   lam :: ll, of_location ~scopes e.exp_loc)
       end
   | Texp_extension_constructor (_, path) ->
       transl_extension_path (of_location ~scopes e.exp_loc) e.exp_env path
   | Texp_variant(l, arg) ->
+      let share_immutable =
+        Translattribute.get_share_immutable_attribute e
+      in
       let tag = Btype.hash_variant l in
       begin match arg with
         None -> Lconst(const_int tag)
@@ -362,13 +371,16 @@ and transl_exp0 ~in_new_scope ~scopes e =
             Lconst(Const_block(0, [const_int tag;
                                    extract_constant lam]))
           with Not_constant ->
-            Lprim(Pmakeblock(0, Immutable, None),
+            Lprim(Pmakeblock(0, Immutable, share_immutable, None),
                   [Lconst(const_int tag); lam],
                   of_location ~scopes e.exp_loc)
       end
   | Texp_record {fields; representation; extended_expression} ->
+      let share_immutable =
+        Translattribute.get_share_immutable_attribute e
+      in
       transl_record ~scopes e.exp_loc e.exp_env
-        fields representation extended_expression
+        fields representation extended_expression share_immutable
   | Texp_field(arg, _, lbl) ->
       let targ = transl_exp ~scopes arg in
       begin match lbl.lbl_repres with
@@ -567,7 +579,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
           (* We don't need to wrap with Popaque: this forward
              block will never be shortcutted since it points to a float
              and Config.flat_float_array is true. *)
-          Lprim(Pmakeblock(Obj.forward_tag, Immutable, None),
+          Lprim(Pmakeblock(Obj.forward_tag, Immutable, Default_share_immutable, None),
                 [transl_exp ~scopes e], of_location ~scopes e.exp_loc)
       | `Identifier `Forward_value ->
          (* CR-someday mshinwell: Consider adding a new primitive
@@ -577,7 +589,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
             block doesn't really match what is going on here.  This
             value may subsequently turn into an immediate... *)
          Lprim (Popaque,
-                [Lprim(Pmakeblock(Obj.forward_tag, Immutable, None),
+                [Lprim(Pmakeblock(Obj.forward_tag, Immutable, Default_share_immutable, None),
                        [transl_exp ~scopes e],
                        of_location ~scopes e.exp_loc)],
                 of_location ~scopes e.exp_loc)
@@ -591,7 +603,7 @@ and transl_exp0 ~in_new_scope ~scopes e =
                             ~attr:default_function_attribute
                             ~loc:(of_location ~scopes e.exp_loc)
                             ~body:(transl_exp ~scopes e) in
-          Lprim(Pmakeblock(Config.lazy_tag, Mutable, None), [fn],
+          Lprim(Pmakeblock(Config.lazy_tag, Mutable, Default_share_immutable, None), [fn],
                 of_location ~scopes e.exp_loc)
       end
   | Texp_object (cs, meths) ->
@@ -932,7 +944,7 @@ and transl_setinstvar ~scopes loc self var expr =
   Lprim(Psetfield_computed (maybe_pointer expr, Assignment),
     [self; var; transl_exp ~scopes expr], loc)
 
-and transl_record ~scopes loc env fields repres opt_init_expr =
+and transl_record ~scopes loc env fields repres opt_init_expr share_immutable =
   let size = Array.length fields in
   (* Determine if there are "enough" fields (only relevant if this is a
      functional-style record update *)
@@ -984,15 +996,15 @@ and transl_record ~scopes loc env fields repres opt_init_expr =
         let loc = of_location ~scopes loc in
         match repres with
           Record_regular ->
-            Lprim(Pmakeblock(0, mut, Some shape), ll, loc)
+            Lprim(Pmakeblock(0, mut, share_immutable, Some shape), ll, loc)
         | Record_inlined tag ->
-            Lprim(Pmakeblock(tag, mut, Some shape), ll, loc)
+            Lprim(Pmakeblock(tag, mut, share_immutable, Some shape), ll, loc)
         | Record_unboxed _ -> (match ll with [v] -> v | _ -> assert false)
         | Record_float ->
             Lprim(Pmakearray (Pfloatarray, mut), ll, loc)
         | Record_extension path ->
             let slot = transl_extension_path loc env path in
-            Lprim(Pmakeblock(0, mut, Some (Pgenval :: shape)), slot :: ll, loc)
+            Lprim(Pmakeblock(0, mut, share_immutable, Some (Pgenval :: shape)), slot :: ll, loc)
     in
     begin match opt_init_expr with
       None -> lam

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -83,7 +83,7 @@ let rec apply_coercion loc strict restr arg =
       name_lambda strict arg (fun id ->
         let get_field pos =
           if pos < 0 then lambda_unit
-          else Lprim(Pfield pos,[Lvar id], loc)
+          else Lprim(Pfield (pos, Mutable),[Lvar id], loc)
         in
         let lam =
           Lprim(Pmakeblock(0, Immutable, None),
@@ -718,7 +718,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                   rebind_idents (pos + 1) (id :: newfields) ids
                 in
                 Llet(Alias, Pgenval, id,
-                     Lprim(Pfield pos, [Lvar mid],
+                     Lprim(Pfield (pos, Mutable), [Lvar mid],
                            of_location ~scopes incl.incl_loc), body),
                 size
           in
@@ -747,7 +747,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
                     rebind_idents (pos + 1) (id :: newfields) ids
                   in
                   Llet(Alias, Pgenval, id,
-                      Lprim(Pfield pos, [Lvar mid],
+                      Lprim(Pfield (pos, Mutable), [Lvar mid],
                             of_location ~scopes od.open_loc), body),
                   size
               in
@@ -966,7 +966,7 @@ let transl_store_subst = ref Ident.Map.empty
 
 let nat_toplevel_name id =
   try match Ident.Map.find id !transl_store_subst with
-    | Lprim(Pfield pos, [Lprim(Pgetglobal glob, [], _)], _) -> (glob,pos)
+    | Lprim(Pfield (pos, _), [Lprim(Pgetglobal glob, [], _)], _) -> (glob,pos)
     | _ -> raise Not_found
   with Not_found ->
     fatal_error("Translmod.nat_toplevel_name: " ^ Ident.unique_name id)
@@ -1202,7 +1202,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
               | [] -> transl_store
                         ~scopes rootpath (add_idents true ids subst) cont rem
               | id :: idl ->
-                  Llet(Alias, Pgenval, id, Lprim(Pfield pos, [Lvar mid],
+                  Llet(Alias, Pgenval, id, Lprim(Pfield (pos, Mutable), [Lvar mid],
                                                  of_location ~scopes loc),
                        Lsequence(store_ident (of_location ~scopes loc) id,
                                  store_idents (pos + 1) idl))
@@ -1248,7 +1248,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
                         [] -> transl_store ~scopes rootpath
                                 (add_idents true ids subst) cont rem
                       | id :: idl ->
-                          Llet(Alias, Pgenval, id, Lprim(Pfield pos, [Lvar mid],
+                          Llet(Alias, Pgenval, id, Lprim(Pfield (pos, Mutable), [Lvar mid],
                                                          loc),
                                Lsequence(store_ident loc id,
                                          store_idents (pos + 1) idl))
@@ -1283,7 +1283,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
       match cc with
         Tcoerce_none ->
           Ident.Map.add id
-            (Lprim(Pfield pos,
+            (Lprim(Pfield (pos, Immutable),
                    [Lprim(Pgetglobal glob, [], Loc_unknown)],
                    Loc_unknown))
             subst
@@ -1422,7 +1422,7 @@ let toplevel_name id =
 let toploop_getvalue id =
   Lapply{
     ap_loc=Loc_unknown;
-    ap_func=Lprim(Pfield toploop_getvalue_pos,
+    ap_func=Lprim(Pfield (toploop_getvalue_pos, Mutable),
                   [Lprim(Pgetglobal toploop_ident, [], Loc_unknown)],
                   Loc_unknown);
     ap_args=[Lconst(Const_base(
@@ -1435,7 +1435,7 @@ let toploop_getvalue id =
 let toploop_setvalue id lam =
   Lapply{
     ap_loc=Loc_unknown;
-    ap_func=Lprim(Pfield toploop_setvalue_pos,
+    ap_func=Lprim(Pfield (toploop_setvalue_pos, Mutable),
                   [Lprim(Pgetglobal toploop_ident, [], Loc_unknown)],
                   Loc_unknown);
     ap_args=
@@ -1520,7 +1520,7 @@ let transl_toplevel_item ~scopes item =
           lambda_unit
       | id :: ids ->
           Lsequence(toploop_setvalue id
-                      (Lprim(Pfield pos, [Lvar mid], Loc_unknown)),
+                      (Lprim(Pfield (pos, Mutable), [Lvar mid], Loc_unknown)),
                     set_idents (pos + 1) ids) in
       Llet(Strict, Pgenval, mid,
            transl_module ~scopes Tcoerce_none None modl, set_idents 0 ids)
@@ -1542,8 +1542,9 @@ let transl_toplevel_item ~scopes item =
               [] ->
                 lambda_unit
             | id :: ids ->
+                (* TODO: same as above *)
                 Lsequence(toploop_setvalue id
-                            (Lprim(Pfield pos, [Lvar mid], Loc_unknown)),
+                            (Lprim(Pfield (pos, Mutable), [Lvar mid], Loc_unknown)),
                           set_idents (pos + 1) ids)
           in
           Llet(pure, Pgenval, mid,
@@ -1646,7 +1647,7 @@ let transl_store_package component_names target_name coercion =
                (fun pos _id ->
                  Lprim(Psetfield(pos, Pointer, Root_initialization),
                        [Lprim(Pgetglobal target_name, [], Loc_unknown);
-                        Lprim(Pfield pos, [Lvar blk], Loc_unknown)],
+                        Lprim(Pfield (pos, Mutable), [Lvar blk], Loc_unknown)],
                        Loc_unknown))
                0 pos_cc_list))
   (*

--- a/lambda/translmod.ml
+++ b/lambda/translmod.ml
@@ -86,7 +86,7 @@ let rec apply_coercion loc strict restr arg =
           else Lprim(Pfield (pos, Mutable),[Lvar id], loc)
         in
         let lam =
-          Lprim(Pmakeblock(0, Immutable, None),
+          Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
                 List.map (apply_coercion_field loc get_field) pos_cc_list,
                 loc)
         in
@@ -542,7 +542,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
       let body, size =
         match cc with
           Tcoerce_none ->
-            Lprim(Pmakeblock(0, Immutable, None),
+            Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
                   List.map (fun id -> Lvar id) (List.rev fields), loc),
               List.length fields
         | Tcoerce_structure(pos_cc_list, id_pos_list) ->
@@ -558,7 +558,7 @@ and transl_structure ~scopes loc fields cc rootpath final_env = function
             in
             let ids = List.fold_right Ident.Set.add fields Ident.Set.empty in
             let lam =
-              Lprim(Pmakeblock(0, Immutable, None),
+              Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
                   List.map
                     (fun (pos, cc) ->
                       match cc with
@@ -1065,7 +1065,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
             Lsequence(lam,
                       Llet(Strict, Pgenval, id,
                            Lambda.subst no_env_update subst
-                             (Lprim(Pmakeblock(0, Immutable, None),
+                             (Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
                                     List.map (fun id -> Lvar id)
                                       (defined_idents str.str_items), loc)),
                            Lsequence(store_ident loc id,
@@ -1097,7 +1097,7 @@ let transl_store_structure ~scopes glob map prims aliases str =
             Lsequence(lam,
                       Llet(Strict, Pgenval, id,
                            Lambda.subst no_env_update subst
-                             (Lprim(Pmakeblock(0, Immutable, None),
+                             (Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
                                     List.map field map, loc)),
                            Lsequence(store_ident loc id,
                                      transl_store ~scopes rootpath
@@ -1591,13 +1591,13 @@ let transl_package_flambda component_names coercion =
   in
   size,
   apply_coercion Loc_unknown Strict coercion
-    (Lprim(Pmakeblock(0, Immutable, None),
+    (Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
            List.map get_component component_names,
            Loc_unknown))
 
 let transl_package component_names target_name coercion =
   let components =
-    Lprim(Pmakeblock(0, Immutable, None),
+    Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
           List.map get_component component_names, Loc_unknown) in
   Lprim(Psetglobal target_name,
         [apply_coercion Loc_unknown Strict coercion components],
@@ -1635,7 +1635,7 @@ let transl_store_package component_names target_name coercion =
          0 component_names)
   | Tcoerce_structure (pos_cc_list, _id_pos_list) ->
       let components =
-        Lprim(Pmakeblock(0, Immutable, None),
+        Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None),
               List.map get_component component_names,
               Loc_unknown)
       in

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -125,7 +125,7 @@ let transl_label_init_flambda f =
 let transl_store_label_init glob size f arg =
   assert(not Config.flambda);
   assert(!Clflags.native_code);
-  method_cache := Lprim(Pfield size,
+  method_cache := Lprim(Pfield (size, Mutable),
                         [Lprim(Pgetglobal glob, [], Loc_unknown)],
                         Loc_unknown);
   let expr = f arg in

--- a/lambda/translobj.ml
+++ b/lambda/translobj.ml
@@ -178,7 +178,7 @@ let oo_wrap env req f x =
            List.fold_left
              (fun lambda id ->
                 Llet(StrictOpt, Pgenval, id,
-                     Lprim(Pmakeblock(0, Mutable, None),
+                     Lprim(Pmakeblock(0, Mutable, Default_share_immutable, None),
                            [lambda_unit; lambda_unit; lambda_unit],
                            Loc_unknown),
                      lambda))

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -127,8 +127,8 @@ let primitives_table =
     "%loc_POS", Loc Loc_POS;
     "%loc_MODULE", Loc Loc_MODULE;
     "%loc_FUNCTION", Loc Loc_FUNCTION;
-    "%field0", Primitive ((Pfield 0), 1);
-    "%field1", Primitive ((Pfield 1), 1);
+    "%field0", Primitive ((Pfield (0, Mutable)), 1);
+    "%field1", Primitive ((Pfield (1, Mutable)), 1);
     "%setfield0", Primitive ((Psetfield(0, Pointer, Assignment)), 2);
     "%makeblock", Primitive ((Pmakeblock(0, Immutable, None)), 1);
     "%makemutable", Primitive ((Pmakeblock(0, Mutable, None)), 1);

--- a/lambda/translprim.ml
+++ b/lambda/translprim.ml
@@ -130,8 +130,8 @@ let primitives_table =
     "%field0", Primitive ((Pfield (0, Mutable)), 1);
     "%field1", Primitive ((Pfield (1, Mutable)), 1);
     "%setfield0", Primitive ((Psetfield(0, Pointer, Assignment)), 2);
-    "%makeblock", Primitive ((Pmakeblock(0, Immutable, None)), 1);
-    "%makemutable", Primitive ((Pmakeblock(0, Mutable, None)), 1);
+    "%makeblock", Primitive ((Pmakeblock(0, Immutable, Default_share_immutable, None)), 1);
+    "%makemutable", Primitive ((Pmakeblock(0, Mutable, Default_share_immutable, None)), 1);
     "%raise", Raise Raise_regular;
     "%reraise", Raise Raise_reraise;
     "%raise_notrace", Raise Raise_notrace;
@@ -466,10 +466,10 @@ let specialize_primitive env ty ~has_constant_constructor prim =
       | Pbigarray_unknown, Pbigarray_unknown_layout -> None
       | _, _ -> Some (Primitive (Pbigarrayset(unsafe, n, k, l), arity))
     end
-  | Primitive (Pmakeblock(tag, mut, None), arity), fields -> begin
+  | Primitive (Pmakeblock(tag, mut, share_immut, None), arity), fields -> begin
       let shape = List.map (Typeopt.value_kind env) fields in
       let useful = List.exists (fun knd -> knd <> Pgenval) shape in
-      if useful then Some (Primitive (Pmakeblock(tag, mut, Some shape), arity))
+      if useful then Some (Primitive (Pmakeblock(tag, mut, share_immut, Some shape), arity))
       else None
     end
   | Comparison(comp, Compare_generic), p1 :: _ ->
@@ -689,7 +689,7 @@ let lambda_of_prim prim_name prim loc args arg_exps =
       lambda_of_loc kind loc
   | Loc kind, [arg] ->
       let lam = lambda_of_loc kind loc in
-      Lprim(Pmakeblock(0, Immutable, None), [lam; arg], loc)
+      Lprim(Pmakeblock(0, Immutable, Default_share_immutable, None), [lam; arg], loc)
   | Send, [obj; meth] ->
       Lsend(Public, meth, obj, [], loc)
   | Send_self, [obj; meth] ->

--- a/middle_end/closure/closure.ml
+++ b/middle_end/closure/closure.ml
@@ -1102,7 +1102,7 @@ let rec close ({ backend; fenv; cenv ; mutable_vars } as env) lam =
       let dbg = Debuginfo.from_location loc in
       check_constant_result (getglobal dbg id)
                             (Compilenv.global_approx id)
-  | Lprim(Pfield n, [lam], loc) ->
+  | Lprim(Pfield (n, _), [lam], loc) ->
       let (ulam, approx) = close env lam in
       let dbg = Debuginfo.from_location loc in
       check_constant_result (Uprim(P.Pfield n, [ulam], dbg))

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -26,7 +26,7 @@ let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   match prim with
   | Pmakeblock (tag, mutability, shape) ->
       Pmakeblock (tag, mutability, shape)
-  | Pfield field -> Pfield field
+  | Pfield (field, _) -> Pfield field
   | Pfield_computed -> Pfield_computed
   | Psetfield (field, imm_or_pointer, init_or_assign) ->
       Psetfield (field, imm_or_pointer, init_or_assign)

--- a/middle_end/convert_primitives.ml
+++ b/middle_end/convert_primitives.ml
@@ -24,7 +24,7 @@ let convert_unsafety is_unsafe : Clambda_primitives.is_safe =
 
 let convert (prim : Lambda.primitive) : Clambda_primitives.primitive =
   match prim with
-  | Pmakeblock (tag, mutability, shape) ->
+  | Pmakeblock (tag, mutability, _, shape) ->
       Pmakeblock (tag, mutability, shape)
   | Pfield (field, _) -> Pfield field
   | Pfield_computed -> Pfield_computed

--- a/testsuite/tests/basic-modules/anonymous.ocamlc.reference
+++ b/testsuite/tests/basic-modules/anonymous.ocamlc.reference
@@ -2,15 +2,15 @@
   (seq (ignore (let (x = [0: 13 37]) (makeblock 0 x)))
     (let
       (A =
-         (apply (field 0 (global CamlinternalMod!)) [0: "anonymous.ml" 25 6]
-           [0: [0]])
+         (apply (field_mut 0 (global CamlinternalMod!))
+           [0: "anonymous.ml" 25 6] [0: [0]])
        B =
-         (apply (field 0 (global CamlinternalMod!)) [0: "anonymous.ml" 35 6]
-           [0: [0]]))
+         (apply (field_mut 0 (global CamlinternalMod!))
+           [0: "anonymous.ml" 35 6] [0: [0]]))
       (seq (ignore (let (x = [0: 4 2]) (makeblock 0 x)))
-        (apply (field 1 (global CamlinternalMod!)) [0: [0]] A
+        (apply (field_mut 1 (global CamlinternalMod!)) [0: [0]] A
           (module-defn(A) Anonymous anonymous.ml(23):567-608 A))
-        (apply (field 1 (global CamlinternalMod!)) [0: [0]] B
+        (apply (field_mut 1 (global CamlinternalMod!)) [0: [0]] B
           (module-defn(B) Anonymous anonymous.ml(33):703-773
             (let (x = [0: "foo" "bar"]) (makeblock 0))))
         (let (f = (function param : int 0) s = (makemutable 0 ""))
@@ -20,5 +20,5 @@
                 (makeblock 0)))
             (let
               (drop = (function param : int 0)
-               *match* = (apply drop (field 0 s)))
+               *match* = (apply drop (field_mut 0 s)))
               (makeblock 0 A B f s drop))))))))

--- a/testsuite/tests/basic-modules/anonymous.ocamlopt.reference
+++ b/testsuite/tests/basic-modules/anonymous.ocamlopt.reference
@@ -1,14 +1,14 @@
 (seq (ignore (let (x = [0: 13 37]) (makeblock 0 x)))
   (let
     (A =
-       (apply (field 0 (global CamlinternalMod!)) [0: "anonymous.ml" 25 6]
-         [0: [0]])
+       (apply (field_mut 0 (global CamlinternalMod!))
+         [0: "anonymous.ml" 25 6] [0: [0]])
      B =
-       (apply (field 0 (global CamlinternalMod!)) [0: "anonymous.ml" 35 6]
-         [0: [0]]))
+       (apply (field_mut 0 (global CamlinternalMod!))
+         [0: "anonymous.ml" 35 6] [0: [0]]))
     (seq (ignore (let (x = [0: 4 2]) (makeblock 0 x)))
-      (apply (field 1 (global CamlinternalMod!)) [0: [0]] A A)
-      (apply (field 1 (global CamlinternalMod!)) [0: [0]] B
+      (apply (field_mut 1 (global CamlinternalMod!)) [0: [0]] A A)
+      (apply (field_mut 1 (global CamlinternalMod!)) [0: [0]] B
         (let (x = [0: "foo" "bar"]) (makeblock 0)))
       (setfield_ptr(root-init) 0 (global Anonymous!) A)
       (setfield_ptr(root-init) 1 (global Anonymous!) B)
@@ -26,6 +26,6 @@
       (let
         (*match* =
            (apply (field 4 (global Anonymous!))
-             (field 0 (field 3 (global Anonymous!)))))
+             (field_mut 0 (field 3 (global Anonymous!)))))
         0)
       0)))

--- a/testsuite/tests/basic/patmatch_split_no_or.ml
+++ b/testsuite/tests/basic/patmatch_split_no_or.ml
@@ -21,7 +21,7 @@ let last_is_anys = function
          (if (field 0 param/13) (if (field 1 param/13) (exit 1) 1)
            (if (field 1 param/13) (exit 1) 2))
         with (1) 3)))
-  (apply (field 1 (global Toploop!)) "last_is_anys" last_is_anys/11))
+  (apply (field_mut 1 (global Toploop!)) "last_is_anys" last_is_anys/11))
 val last_is_anys : bool * bool -> int = <fun>
 |}]
 
@@ -38,7 +38,7 @@ let last_is_vars = function
          (if (field 0 param/22) (if (field 1 param/22) (exit 3) 1)
            (if (field 1 param/22) (exit 3) 2))
         with (3) 3)))
-  (apply (field 1 (global Toploop!)) "last_is_vars" last_is_vars/18))
+  (apply (field_mut 1 (global Toploop!)) "last_is_vars" last_is_vars/18))
 val last_is_vars : bool * bool -> int = <fun>
 |}]
 
@@ -55,9 +55,9 @@ type t = ..
   (A/26 = (makeblock 248 "A" (caml_fresh_oo_id 0))
    B/27 = (makeblock 248 "B" (caml_fresh_oo_id 0))
    C/28 = (makeblock 248 "C" (caml_fresh_oo_id 0)))
-  (seq (apply (field 1 (global Toploop!)) "A/26" A/26)
-    (apply (field 1 (global Toploop!)) "B/27" B/27)
-    (apply (field 1 (global Toploop!)) "C/28" C/28)))
+  (seq (apply (field_mut 1 (global Toploop!)) "A/26" A/26)
+    (apply (field_mut 1 (global Toploop!)) "B/27" B/27)
+    (apply (field_mut 1 (global Toploop!)) "C/28" C/28)))
 type t += A | B of unit | C of bool * int
 |}]
 
@@ -71,9 +71,9 @@ let f = function
 ;;
 [%%expect{|
 (let
-  (C/28 = (apply (field 0 (global Toploop!)) "C/28")
-   B/27 = (apply (field 0 (global Toploop!)) "B/27")
-   A/26 = (apply (field 0 (global Toploop!)) "A/26")
+  (C/28 = (apply (field_mut 0 (global Toploop!)) "C/28")
+   B/27 = (apply (field_mut 0 (global Toploop!)) "B/27")
+   A/26 = (apply (field_mut 0 (global Toploop!)) "A/26")
    f/29 =
      (function param/31 : int
        (let (*match*/32 =a (field 0 param/31))
@@ -85,6 +85,6 @@ let f = function
              (if (== (field 0 *match*/32) B/27) 2
                (if (== (field 0 *match*/32) C/28) 3 4))
              (if (field 2 param/31) 12 11))))))
-  (apply (field 1 (global Toploop!)) "f" f/29))
+  (apply (field_mut 1 (global Toploop!)) "f" f/29))
 val f : t * bool * bool -> int = <fun>
 |}]

--- a/testsuite/tests/functors/functors.compilers.reference
+++ b/testsuite/tests/functors/functors.compilers.reference
@@ -4,7 +4,7 @@
        (module-defn(O) Functors functors.ml(12):184-279
          (function X is_a_functor always_inline
            (let
-             (cow = (function x[int] : int (apply (field 0 X) x))
+             (cow = (function x[int] : int (apply (field_mut 0 X) x))
               sheep = (function x[int] : int (+ 1 (apply cow x))))
              (makeblock 0 cow sheep))))
      F =
@@ -13,7 +13,7 @@
            (let
              (cow =
                 (function x[int] : int
-                  (apply (field 0 Y) (apply (field 0 X) x)))
+                  (apply (field_mut 0 Y) (apply (field_mut 0 X) x)))
               sheep = (function x[int] : int (+ 1 (apply cow x))))
              (makeblock 0 cow sheep))))
      F1 =
@@ -22,17 +22,17 @@
            (let
              (sheep =
                 (function x[int] : int
-                  (+ 1 (apply (field 0 Y) (apply (field 0 X) x)))))
+                  (+ 1 (apply (field_mut 0 Y) (apply (field_mut 0 X) x)))))
              (makeblock 0 sheep))))
      F2 =
        (module-defn(F2) Functors functors.ml(36):634-784
          (function X Y is_a_functor always_inline
            (let
-             (X =a (makeblock 0 (field 1 X))
-              Y =a (makeblock 0 (field 1 Y))
+             (X =a (makeblock 0 (field_mut 1 X))
+              Y =a (makeblock 0 (field_mut 1 Y))
               sheep =
                 (function x[int] : int
-                  (+ 1 (apply (field 0 Y) (apply (field 0 X) x)))))
+                  (+ 1 (apply (field_mut 0 Y) (apply (field_mut 0 X) x)))))
              (makeblock 0 sheep))))
      M =
        (module-defn(M) Functors functors.ml(41):786-970
@@ -43,14 +43,14 @@
                   (let
                     (cow =
                        (function x[int] : int
-                         (apply (field 0 Y) (apply (field 0 X) x)))
+                         (apply (field_mut 0 Y) (apply (field_mut 0 X) x)))
                      sheep = (function x[int] : int (+ 1 (apply cow x))))
                     (makeblock 0 cow sheep)))))
            (makeblock 0
              (function funarg funarg is_a_functor stub
                (let
                  (let =
-                    (apply F (makeblock 0 (field 1 funarg))
-                      (makeblock 0 (field 1 funarg))))
-                 (makeblock 0 (field 1 let))))))))
+                    (apply F (makeblock 0 (field_mut 1 funarg))
+                      (makeblock 0 (field_mut 1 funarg))))
+                 (makeblock 0 (field_mut 1 let))))))))
     (makeblock 0 O F F1 F2 M)))

--- a/testsuite/tests/share-immut/share-immut.ml
+++ b/testsuite/tests/share-immut/share-immut.ml
@@ -28,11 +28,11 @@ let non_op = function
 
 let to_immut = function
   | MEmpty dummy -> Empty dummy [@share] (* ok, shared *)
-  | MFull data -> Full data.data [@share] (* not ok, not shared *)
+  | MFull data -> Full data.data [@share] (* warned, not shared *)
 
 let to_mut = function
   | Empty dummy -> MEmpty dummy [@share] (* ok, shared *)
-  | Full data -> MFull ({ data } [@share]) (* not ok, warned *)
+  | Full data -> MFull ({ data } [@share]) (* warned, not shared *)
 
 let to_mut_wrongly_annotated = function
   | Empty dummy -> MEmpty dummy [@share] (* ok, shared *)

--- a/testsuite/tests/share-immut/share-immut.ml
+++ b/testsuite/tests/share-immut/share-immut.ml
@@ -1,0 +1,51 @@
+(* TEST
+
+flags = "-w -A -dlambda"
+
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+*** check-ocamlc.byte-output
+compiler_reference = "${test_source_directory}/share-immut.ocamlc.reference"
+
+* setup-ocamlopt.byte-build-env
+** ocamlopt.byte
+*** no-flambda
+**** check-ocamlopt.byte-output
+compiler_reference = "${test_source_directory}/share-immut.ocamlopt.reference"
+*)
+
+type 'a mut_cell =
+  | MEmpty of int
+  | MFull of { mutable data: 'a }
+
+type 'a cell =
+  | Empty of int
+  | Full of 'a
+
+let non_op = function
+  | Empty dummy -> Empty dummy [@share] (* ok, shared *)
+  | Full data -> Full data [@share] (* ok, shared *)
+
+let to_immut = function
+  | MEmpty dummy -> Empty dummy [@share] (* ok, shared *)
+  | MFull data -> Full data.data [@share] (* not ok, not shared *)
+
+let to_mut = function
+  | Empty dummy -> MEmpty dummy [@share] (* ok, shared *)
+  | Full data -> MFull ({ data } [@share]) (* not ok, warned *)
+
+let to_mut_wrongly_annotated = function
+  | Empty dummy -> MEmpty dummy [@share] (* ok, shared *)
+  | Full data -> MFull { data } [@share] (* [share] on `Texp_construct` but not `Texp_record`, silent *)
+
+let to_immut_with_hint = function
+  | MEmpty dummy -> Empty dummy [@share hint] (* ok, shared *)
+  | MFull data -> Full data.data [@share hint] (* ok, not shared *)
+
+let non_op_with_never = function
+  | Empty dummy -> Empty dummy [@share never] (* ok, not shared *)
+  | Full data -> Full data [@share never] (* ok, not shared *)
+
+let non_op_with_always = function
+  | Empty dummy -> Empty dummy [@share always] (* ok, shared *)
+  | Full data -> Full data [@share always] (* ok, shared *)

--- a/testsuite/tests/share-immut/share-immut.ocamlc.reference
+++ b/testsuite/tests/share-immut/share-immut.ocamlc.reference
@@ -1,0 +1,38 @@
+(setglobal Share-immut!
+  (let
+    (non_op/274 =
+       (function param/278
+         (switch* param/278 case tag 0: param/278
+                            case tag 1: param/278))
+     to_immut/279 =
+       (function param/283
+         (switch* param/283
+          case tag 0: param/283
+          case tag 1: (makeblock 1 share(always) (field_mut 0 param/283))))
+     to_mut/284 =
+       (function param/288
+         (switch* param/288
+          case tag 0: param/288
+          case tag 1: (makemutable 1 share(always) (field 0 param/288))))
+     to_mut_wrongly_annotated/289 =
+       (function param/293
+         (switch* param/293
+          case tag 0: param/293
+          case tag 1: (makemutable 1 (field 0 param/293))))
+     to_immut_with_hint/294 =
+       (function param/298
+         (switch* param/298
+          case tag 0: param/298
+          case tag 1: (makeblock 1 share(hint) (field_mut 0 param/298))))
+     non_op_with_never/299 =
+       (function param/303
+         (switch* param/303
+          case tag 0: (makeblock 0 (int) (field 0 param/303))
+          case tag 1: (makeblock 1 (field 0 param/303))))
+     non_op_with_always/304 =
+       (function param/308
+         (switch* param/308 case tag 0: param/308
+                            case tag 1: param/308)))
+    (makeblock 0 non_op/274 to_immut/279 to_mut/284
+      to_mut_wrongly_annotated/289 to_immut_with_hint/294
+      non_op_with_never/299 non_op_with_always/304)))

--- a/testsuite/tests/share-immut/share-immut.ocamlopt.reference
+++ b/testsuite/tests/share-immut/share-immut.ocamlopt.reference
@@ -1,0 +1,50 @@
+(seq
+  (let
+    (non_op/274 =
+       (function param/278
+         (switch* param/278 case tag 0: param/278
+                            case tag 1: param/278)))
+    (setfield_ptr(root-init) 0 (global Share-immut!) non_op/274))
+  (let
+    (to_immut/279 =
+       (function param/283
+         (switch* param/283
+          case tag 0: param/283
+          case tag 1: (makeblock 1 share(always) (field_mut 0 param/283)))))
+    (setfield_ptr(root-init) 1 (global Share-immut!) to_immut/279))
+  (let
+    (to_mut/284 =
+       (function param/288
+         (switch* param/288
+          case tag 0: param/288
+          case tag 1: (makemutable 1 share(always) (field 0 param/288)))))
+    (setfield_ptr(root-init) 2 (global Share-immut!) to_mut/284))
+  (let
+    (to_mut_wrongly_annotated/289 =
+       (function param/293
+         (switch* param/293
+          case tag 0: param/293
+          case tag 1: (makemutable 1 (field 0 param/293)))))
+    (setfield_ptr(root-init) 3 (global Share-immut!)
+      to_mut_wrongly_annotated/289))
+  (let
+    (to_immut_with_hint/294 =
+       (function param/298
+         (switch* param/298
+          case tag 0: param/298
+          case tag 1: (makeblock 1 share(hint) (field_mut 0 param/298)))))
+    (setfield_ptr(root-init) 4 (global Share-immut!) to_immut_with_hint/294))
+  (let
+    (non_op_with_never/299 =
+       (function param/303
+         (switch* param/303
+          case tag 0: (makeblock 0 (int) (field 0 param/303))
+          case tag 1: (makeblock 1 (field 0 param/303)))))
+    (setfield_ptr(root-init) 5 (global Share-immut!) non_op_with_never/299))
+  (let
+    (non_op_with_always/304 =
+       (function param/308
+         (switch* param/308 case tag 0: param/308
+                            case tag 1: param/308)))
+    (setfield_ptr(root-init) 6 (global Share-immut!) non_op_with_always/304))
+  0)

--- a/testsuite/tests/tmc/readable_output.ml
+++ b/testsuite/tests/tmc/readable_output.ml
@@ -24,7 +24,7 @@ let[@tail_mod_cons] rec map f = function
             (seq (setfield_ptr(heap-init)_computed dst offset block)
               (apply map_dps block 1 f (field 1 param) tailcall)))
           (setfield_ptr(heap-init)_computed dst offset 0))))
-  (apply (field 1 (global Toploop!)) "map" map))
+  (apply (field_mut 1 (global Toploop!)) "map" map))
 val map : ('a -> 'b) -> 'a list -> 'b list = <fun>
 |}]
 
@@ -63,7 +63,7 @@ let[@tail_mod_cons] rec rec_map f = function
                 (makeblock 0 block))
               (apply rec_map_dps block 1 f (field 1 *match*) tailcall)))
           (setfield_ptr(heap-init)_computed dst offset 0))))
-  (apply (field 1 (global Toploop!)) "rec_map" rec_map))
+  (apply (field_mut 1 (global Toploop!)) "rec_map" rec_map))
 val rec_map : ('a -> 'b) -> 'a rec_list -> 'b rec_list = <fun>
 |}]
 
@@ -99,7 +99,7 @@ let[@tail_mod_cons] rec trip = function
                 (makeblock 0 block0_arg0 (makeblock 0 block1_arg0 block)))
               (apply trip_dps block 1 (field 1 param) tailcall)))
           (setfield_ptr(heap-init)_computed dst offset 0))))
-  (apply (field 1 (global Toploop!)) "trip" trip))
+  (apply (field_mut 1 (global Toploop!)) "trip" trip))
 val trip : 'a list -> ('a * int) list = <fun>
 |}]
 
@@ -133,7 +133,7 @@ let[@tail_mod_cons] rec effects f = function
                 (makeblock 0 block0_arg0 block))
               (apply effects_dps block 1 f (field 1 param) tailcall)))
           (setfield_ptr(heap-init)_computed dst offset 0))))
-  (apply (field 1 (global Toploop!)) "effects" effects))
+  (apply (field_mut 1 (global Toploop!)) "effects" effects))
 val effects : ('a -> 'b) -> ('a * 'a) list -> 'b list = <fun>
 |}]
 
@@ -171,7 +171,7 @@ let[@tail_mod_cons] rec map_stutter f xs =
                 (seq (setfield_ptr(heap-init)_computed block 1 block)
                   (apply map_stutter_dps block 1 f (field 1 xs) tailcall)))
               (setfield_ptr(heap-init)_computed block 1 0))))))
-  (apply (field 1 (global Toploop!)) "map_stutter" map_stutter))
+  (apply (field_mut 1 (global Toploop!)) "map_stutter" map_stutter))
 val map_stutter : ('a option -> 'b) -> 'a list -> 'b list = <fun>
 |}]
 
@@ -215,6 +215,6 @@ type 'a stream = { hd : 'a; tl : unit -> 'a stream; }
                 (makeblock 0 block0_arg0 block))
               (apply smap_stutter_dps block 1 f (apply (field 1 xs) 0)
                 (- n 1) tailcall))))))
-  (apply (field 1 (global Toploop!)) "smap_stutter" smap_stutter))
+  (apply (field_mut 1 (global Toploop!)) "smap_stutter" smap_stutter))
 val smap_stutter : ('a option -> 'b) -> 'a stream -> int -> 'b list = <fun>
 |}]

--- a/testsuite/tests/translprim/comparison_table.compilers.reference
+++ b/testsuite/tests/translprim/comparison_table.compilers.reference
@@ -158,7 +158,8 @@
               (function f param (apply f (field 0 param) (field 1 param)))
             map =
               (function f l
-                (apply (field 18 (global Stdlib__List!)) (apply uncurry f) l)))
+                (apply (field_mut 18 (global Stdlib__List!))
+                  (apply uncurry f) l)))
            (makeblock 0
              (makeblock 0 (apply map gen_cmp vec) (apply map cmp vec))
              (apply map
@@ -196,7 +197,7 @@
                     (apply f (field 0 param) (field 1 param)))
                 map =
                   (function f l
-                    (apply (field 18 (global Stdlib__List!))
+                    (apply (field_mut 18 (global Stdlib__List!))
                       (apply uncurry f) l)))
                (makeblock 0
                  (makeblock 0 (apply map eta_gen_cmp vec)

--- a/testsuite/tests/warnings/w73.compilers.reference
+++ b/testsuite/tests/warnings/w73.compilers.reference
@@ -1,11 +1,11 @@
 File "w73.ml", line 30, characters 23-42:
-30 |   | Full data -> MFull ({ data } [@share]) (* not ok, warned *)
+30 |   | Full data -> MFull ({ data } [@share]) (* warned, not shared *)
                             ^^^^^^^^^^^^^^^^^^^
 Warning 73 [share-immutable-block-failed]: Immutable block sharing failed
 because the tag didn't match, or the new block contains mutable fields,
 or the arguments were not all immutable fields of the original block.
 File "w73.ml", line 26, characters 18-32:
-26 |   | MFull data -> Full data.data [@share] (* not ok, not shared *)
+26 |   | MFull data -> Full data.data [@share] (* warned, not shared *)
                        ^^^^^^^^^^^^^^
 Warning 73 [share-immutable-block-failed]: Immutable block sharing failed
 because the tag didn't match, or the new block contains mutable fields,

--- a/testsuite/tests/warnings/w73.compilers.reference
+++ b/testsuite/tests/warnings/w73.compilers.reference
@@ -1,0 +1,12 @@
+File "w73.ml", line 30, characters 23-42:
+30 |   | Full data -> MFull ({ data } [@share]) (* not ok, warned *)
+                            ^^^^^^^^^^^^^^^^^^^
+Warning 73 [share-immutable-block-failed]: Immutable block sharing failed
+because the tag didn't match, or the new block contains mutable fields,
+or the arguments were not all immutable fields of the original block.
+File "w73.ml", line 26, characters 18-32:
+26 |   | MFull data -> Full data.data [@share] (* not ok, not shared *)
+                       ^^^^^^^^^^^^^^
+Warning 73 [share-immutable-block-failed]: Immutable block sharing failed
+because the tag didn't match, or the new block contains mutable fields,
+or the arguments were not all immutable fields of the original block.

--- a/testsuite/tests/warnings/w73.ml
+++ b/testsuite/tests/warnings/w73.ml
@@ -1,0 +1,46 @@
+(* TEST
+
+flags = "-w +A-70"
+
+* setup-ocamlc.byte-build-env
+** ocamlc.byte
+compile_only = "true"
+*** check-ocamlc.byte-output
+
+*)
+
+type 'a mut_cell =
+  | MEmpty of int
+  | MFull of { mutable data: 'a }
+
+type 'a cell =
+  | Empty of int
+  | Full of 'a
+
+let non_op = function
+  | Empty dummy -> Empty dummy [@share] (* ok, shared *)
+  | Full data -> Full data [@share] (* ok, shared *)
+
+let to_immut = function
+  | MEmpty dummy -> Empty dummy [@share] (* ok, shared *)
+  | MFull data -> Full data.data [@share] (* not ok, not shared *)
+
+let to_mut = function
+  | Empty dummy -> MEmpty dummy [@share] (* ok, shared *)
+  | Full data -> MFull ({ data } [@share]) (* not ok, warned *)
+
+let to_mut_wrongly_annotated = function
+  | Empty dummy -> MEmpty dummy [@share] (* ok, shared *)
+  | Full data -> MFull { data } [@share] (* [share] on `Texp_construct` but not `Texp_record`, silent *)
+
+let to_immut_with_hint = function
+  | MEmpty dummy -> Empty dummy [@share hint] (* ok, shared *)
+  | MFull data -> Full data.data [@share hint] (* ok, not shared *)
+
+let non_op_with_never = function
+  | Empty dummy -> Empty dummy [@share never] (* ok, not shared *)
+  | Full data -> Full data [@share never] (* ok, not shared *)
+
+let non_op_with_always = function
+  | Empty dummy -> Empty dummy [@share always] (* ok, shared *)
+  | Full data -> Full data [@share always] (* ok, shared *)

--- a/testsuite/tests/warnings/w73.ml
+++ b/testsuite/tests/warnings/w73.ml
@@ -23,11 +23,11 @@ let non_op = function
 
 let to_immut = function
   | MEmpty dummy -> Empty dummy [@share] (* ok, shared *)
-  | MFull data -> Full data.data [@share] (* not ok, not shared *)
+  | MFull data -> Full data.data [@share] (* warned, not shared *)
 
 let to_mut = function
   | Empty dummy -> MEmpty dummy [@share] (* ok, shared *)
-  | Full data -> MFull ({ data } [@share]) (* not ok, warned *)
+  | Full data -> MFull ({ data } [@share]) (* warned, not shared *)
 
 let to_mut_wrongly_annotated = function
   | Empty dummy -> MEmpty dummy [@share] (* ok, shared *)

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -53,7 +53,8 @@ let close_phrase lam =
   Ident.Set.fold (fun id l ->
     let glb, pos = toplevel_value id in
     let glob =
-      Lprim (Pfield pos,
+      (* TODO: check this *)
+      Lprim (Pfield (pos, Mutable),
              [Lprim (Pgetglobal glb, [], Loc_unknown)],
              Loc_unknown)
     in

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -53,7 +53,6 @@ let close_phrase lam =
   Ident.Set.fold (fun id l ->
     let glb, pos = toplevel_value id in
     let glob =
-      (* TODO: check this *)
       Lprim (Pfield (pos, Mutable),
              [Lprim (Pgetglobal glb, [], Loc_unknown)],
              Loc_unknown)

--- a/utils/warnings.ml
+++ b/utils/warnings.ml
@@ -107,6 +107,7 @@ type t =
   | Missing_mli                             (* 70 *)
   | Unused_tmc_attribute                    (* 71 *)
   | Tmc_breaks_tailcall                     (* 72 *)
+  | Share_immutable_block_failed            (* 73 *)
 ;;
 
 (* If you remove a warning, leave a hole in the numbering.  NEVER change
@@ -189,9 +190,10 @@ let number = function
   | Missing_mli -> 70
   | Unused_tmc_attribute -> 71
   | Tmc_breaks_tailcall -> 72
+  | Share_immutable_block_failed -> 73
 ;;
 
-let last_warning_number = 72
+let last_warning_number = 73
 ;;
 
 type description =
@@ -446,6 +448,9 @@ let descriptions = [
     names = ["tmc-breaks-tailcall"];
     description = "A tail call is turned into a non-tail call \
                    by the @tail_mod_cons transformation." };
+  { number = 73;
+    names = ["share-immutable-block-failed"];
+    description = "Share immutable block failed." };
 ]
 ;;
 
@@ -1045,6 +1050,10 @@ let message = function
        Please either mark the called function with the [@tail_mod_cons]\n\
        attribute, or mark this call with the [@tailcall false] attribute\n\
        to make its non-tailness explicit."
+  | Share_immutable_block_failed ->
+      "Immutable block sharing failed\n\
+       because the tag didn't match, or the new block contains mutable fields,\n\
+       or the arguments were not all immutable fields of the original block."
 ;;
 
 let nerrors = ref 0;;

--- a/utils/warnings.mli
+++ b/utils/warnings.mli
@@ -109,6 +109,7 @@ type t =
   | Missing_mli                             (* 70 *)
   | Unused_tmc_attribute                    (* 71 *)
   | Tmc_breaks_tailcall                     (* 72 *)
+  | Share_immutable_block_failed            (* 73 *)
 ;;
 
 type alert = {kind:string; message:string; def:loc; use:loc}


### PR DESCRIPTION
Manual annotation with warning.

```
File "w73.ml", line 30, characters 23-42:
30 |   | Full data -> MFull ({ data } [@share]) (* warned, not shared *)
                            ^^^^^^^^^^^^^^^^^^^
Warning 73 [share-immutable-block-failed]: Immutable block sharing failed
because the tag didn't match, or the new block contains mutable fields,
or the arguments were not all immutable fields of the original block.
File "w73.ml", line 26, characters 18-32:
26 |   | MFull data -> Full data.data [@share] (* warned, not shared *)
                       ^^^^^^^^^^^^^^
Warning 73 [share-immutable-block-failed]: Immutable block sharing failed
because the tag didn't match, or the new block contains mutable fields,
or the arguments were not all immutable fields of the original block.
```

```ocaml

type 'a mut_cell =
  | MEmpty of int
  | MFull of { mutable data: 'a }

type 'a cell =
  | Empty of int
  | Full of 'a

let non_op = function
  | Empty dummy -> Empty dummy [@share] (* ok, shared *)
  | Full data -> Full data [@share] (* ok, shared *)

let to_immut = function
  | MEmpty dummy -> Empty dummy [@share] (* ok, shared *)
  | MFull data -> Full data.data [@share] (* warned, not shared *)

let to_mut = function
  | Empty dummy -> MEmpty dummy [@share] (* ok, shared *)
  | Full data -> MFull ({ data } [@share]) (* warned, not shared *)

let to_mut_wrongly_annotated = function
  | Empty dummy -> MEmpty dummy [@share] (* ok, shared *)
  | Full data -> MFull { data } [@share] (* [share] on `Texp_construct` but not `Texp_record`, silent *)

let to_immut_with_hint = function
  | MEmpty dummy -> Empty dummy [@share hint] (* ok, shared *)
  | MFull data -> Full data.data [@share hint] (* ok, not shared *)

let non_op_with_never = function
  | Empty dummy -> Empty dummy [@share never] (* ok, not shared *)
  | Full data -> Full data [@share never] (* ok, not shared *)

let non_op_with_always = function
  | Empty dummy -> Empty dummy [@share always] (* ok, shared *)
  | Full data -> Full data [@share always] (* ok, shared *)

```